### PR TITLE
Add support for git diff input

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Usage:    flatito PATH [options]
 Example:  flatito . -k "search string" -e "json,yaml"
 Example:  flatito . -c "search value"
 Example:  cat file.yaml | flatito -k "search string"
+Example:  git diff | flatito -k "search string"
 
     -h, --help                       Prints this help
     -V, --version                    Show version
@@ -42,6 +43,7 @@ Example:  cat file.yaml | flatito -k "search string"
     -e, --extensions=EXTENSIONS      File extensions to search, separated by comma, default: (json,yaml,yaml)
         --no-skipping                Do not skip hidden files
         --no-gitignore               Do not respect .gitignore
+        --side=SIDE                  When input is a diff: before, after, or both (default: both)
 ```
 
 Searches are case-insensitive by default. Use `-s` to force exact case matching.
@@ -52,6 +54,31 @@ Both `-k` and `-c` support regular expressions and can be combined:
 # Find keys matching "database" with values containing "production"
 flatito . -k "database" -c "production"
 ```
+
+### Searching inside a `git diff`
+
+When the input piped through stdin is a unified diff (e.g. the output of `git diff`),
+flatito reports only the YAML/JSON entries whose lines were added (`+`) or
+removed (`-`) by the diff. Each result is prefixed accordingly.
+
+```sh
+# Show every changed key in the working tree
+git diff | flatito
+
+# Inspect a specific commit, branch range, or staged changes
+git diff HEAD~1 | flatito -k "version"
+git diff main..feature | flatito -c "production"
+git diff --cached | flatito
+
+# Pick a side: only what was added, only what was removed, or both
+git diff | flatito --side=after
+git diff | flatito --side=before
+```
+
+When the diff includes git index hashes (the default for `git diff`), flatito
+reads the original content via `git cat-file` so nested keys retain their
+parent context. If those blobs are unavailable, it falls back to reconstructing
+the changed regions from the diff hunks alone.
 
 ## Development
 

--- a/exe/flatito
+++ b/exe/flatito
@@ -6,6 +6,7 @@ require "optparse"
 
 # If no arguments are given, print help
 stdin = $stdin.read unless $stdin.tty?
+stdin = nil if stdin && stdin.empty?
 ARGV << "-h" if ARGV.empty? && !stdin
 
 options = {}
@@ -15,6 +16,7 @@ OptionParser.new do |opts|
     Example:  flatito . -k "search string" -e "json,yaml"
     Example:  flatito . -c "search value"
     Example:  cat file.yaml | flatito -k "search string"
+    Example:  git diff | flatito -k "search string"
   HEREDOC
 
   opts.on("-h", "--help", "Prints this help") do
@@ -54,12 +56,33 @@ OptionParser.new do |opts|
   opts.on("--no-gitignore", "Do not respect .gitignore") do
     options[:gitignore] = false
   end
+
+  opts.on("--side=SIDE", %w[before after both],
+          "When input is a diff, which side to report (before, after, both). Default: both") do |s|
+    options[:side] = s.to_sym
+  end
 end.parse!
 
 Flatito::Config.prepare_with_options(options)
 
-matched = if stdin
+def diff_from_argv(argv)
+  return nil unless argv.size == 1
+
+  path = argv.first
+  return nil unless File.file?(path)
+
+  content = File.read(path)
+  Flatito::DiffParser.diff?(content) ? content : nil
+end
+
+argv_diff = diff_from_argv(ARGV)
+
+matched = if stdin && Flatito::DiffParser.diff?(stdin)
+            Flatito.from_diff(stdin, options)
+          elsif stdin
             Flatito.flat_content(stdin, options)
+          elsif argv_diff
+            Flatito.from_diff(argv_diff, options)
           else
             Flatito.search(ARGV, options)
           end

--- a/lib/flatito.rb
+++ b/lib/flatito.rb
@@ -12,8 +12,12 @@ require_relative "flatito/renderer"
 require_relative "flatito/regex_from_search"
 require_relative "flatito/print_items"
 require_relative "flatito/config"
+require_relative "flatito/diff_parser"
+require_relative "flatito/diff_source"
 
 module Flatito
+  DEFAULT_DIFF_EXTENSIONS = %w[.json .yml .yaml].freeze
+
   class << self
     def search(paths, options = {})
       Finder.new(paths, options).call
@@ -25,6 +29,63 @@ module Flatito
     def flat_content(content, options = {})
       items = FlattenYaml.items_from_content(content)
       PrintItems.new(options[:search], options[:search_value], case_sensitive: options[:case_sensitive]).print(items) || false
+    end
+
+    def from_diff(diff_content, options = {})
+      side = (options[:side] || :both).to_sym
+      extensions = normalize_extensions(options[:extensions])
+      printer = PrintItems.new(options[:search], options[:search_value],
+                               case_sensitive: options[:case_sensitive])
+
+      matched = false
+      DiffParser.parse(diff_content).each do |file|
+        next unless extension_match?(file.path, extensions)
+
+        before, after = DiffSource.contents_for(file)
+        items = collect_items(file, before, after, side)
+        next if items.empty?
+
+        matched = true if printer.print(items, file.path)
+      end
+      matched
+    rescue Interrupt
+      warn "\nInterrupted"
+      nil
+    end
+
+    private
+
+    def collect_items(file, before, after, side)
+      items = []
+      if %i[after both].include?(side) && after
+        items.concat(filter_changed(FlattenYaml.items_from_content(after, pathname: file.path),
+                                    file.added_lines, :add))
+      end
+      if %i[before both].include?(side) && before
+        items.concat(filter_changed(FlattenYaml.items_from_content(before, pathname: file.path),
+                                    file.removed_lines, :del))
+      end
+      items.sort_by { |item| [item.line, item.marker == :del ? 0 : 1] }
+    end
+
+    def filter_changed(items, line_set, marker)
+      items.filter_map do |item|
+        next unless line_set.include?(item.line)
+
+        FlattenYaml::Item.new(key: item.key, value: item.value, line: item.line, marker: marker)
+      end
+    end
+
+    def normalize_extensions(extensions)
+      list = extensions || %w[json yml yaml]
+      list.map { |ext| ext.start_with?(".") ? ext : ".#{ext}" }
+    end
+
+    def extension_match?(path, extensions)
+      return false if path.nil?
+
+      ext = ::File.extname(path)
+      extensions.include?(ext)
     end
   end
 end

--- a/lib/flatito/diff_parser.rb
+++ b/lib/flatito/diff_parser.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "set"
+
+module Flatito
+  class DiffParser
+    File = Struct.new(
+      :path, :before_path, :after_path,
+      :before_blob, :after_blob,
+      :hunks, :added_lines, :removed_lines,
+      :new_file, :deleted_file,
+      keyword_init: true
+    )
+
+    Hunk = Struct.new(:old_start, :old_count, :new_start, :new_count, :lines, keyword_init: true)
+
+    HUNK_HEADER = /\A@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/
+    INDEX_LINE = /\Aindex ([0-9a-f]+)\.\.([0-9a-f]+)/
+
+    def self.parse(content)
+      new(content).parse
+    end
+
+    def self.diff?(content)
+      return false if content.nil? || content.empty?
+
+      head = content.byteslice(0, 4096).to_s
+      head.start_with?("diff --git ") ||
+        (head.include?("\n--- ") && head.include?("\n+++ ") && head.include?("\n@@ "))
+    end
+
+    def initialize(content)
+      @lines = content.lines
+      @i = 0
+    end
+
+    def parse
+      files = []
+      current = nil
+
+      while @i < @lines.size
+        line = @lines[@i]
+
+        if line.start_with?("diff --git ")
+          files << current if current && !current.path.nil?
+          current = new_file_record
+          @i += 1
+          next
+        end
+
+        unless current
+          @i += 1
+          next
+        end
+
+        if (m = line.match(INDEX_LINE))
+          current.before_blob = m[1]
+          current.after_blob = m[2]
+        elsif line.start_with?("new file mode")
+          current.new_file = true
+        elsif line.start_with?("deleted file mode")
+          current.deleted_file = true
+        elsif line.start_with?("--- ")
+          handle_minus_header(line, current)
+        elsif line.start_with?("+++ ")
+          handle_plus_header(line, current)
+        elsif (m = line.match(HUNK_HEADER))
+          @i += 1
+          consume_hunk(current, m)
+          next
+        end
+
+        @i += 1
+      end
+
+      files << current if current && !current.path.nil?
+      files
+    end
+
+    private
+
+    def new_file_record
+      File.new(
+        hunks: [],
+        added_lines: Set.new,
+        removed_lines: Set.new,
+        new_file: false,
+        deleted_file: false
+      )
+    end
+
+    DEV_NULL = "/dev/null" # rubocop:disable Style/FileNull
+    private_constant :DEV_NULL
+
+    def handle_minus_header(line, current)
+      raw = line[4..].to_s.chomp
+      path = raw.split("\t", 2).first.to_s
+      if path == DEV_NULL
+        current.new_file = true
+      elsif path.start_with?("a/")
+        current.before_path = path[2..]
+      else
+        current.before_path = path
+      end
+    end
+
+    def handle_plus_header(line, current)
+      raw = line[4..].to_s.chomp
+      path = raw.split("\t", 2).first.to_s
+      if path == DEV_NULL
+        current.deleted_file = true
+      elsif path.start_with?("b/")
+        current.after_path = path[2..]
+      else
+        current.after_path = path
+      end
+      current.path ||= current.after_path || current.before_path
+    end
+
+    def consume_hunk(current, header_match)
+      old_ln = header_match[1].to_i
+      new_ln = header_match[3].to_i
+      hunk = Hunk.new(
+        old_start: old_ln,
+        old_count: (header_match[2] || "1").to_i,
+        new_start: new_ln,
+        new_count: (header_match[4] || "1").to_i,
+        lines: []
+      )
+
+      while @i < @lines.size
+        hl = @lines[@i]
+        break if hl.start_with?("diff --git ", "@@ ", "--- ", "+++ ")
+
+        if hl.start_with?("+")
+          hunk.lines << { kind: :add, text: hl[1..].to_s }
+          current.added_lines << new_ln
+          new_ln += 1
+        elsif hl.start_with?("-")
+          hunk.lines << { kind: :del, text: hl[1..].to_s }
+          current.removed_lines << old_ln
+          old_ln += 1
+        elsif hl.start_with?(" ")
+          hunk.lines << { kind: :context, text: hl[1..].to_s }
+          old_ln += 1
+          new_ln += 1
+        elsif hl.start_with?("\\")
+          # "\ No newline at end of file" — ignore
+        elsif hl == "\n" || hl.empty?
+          hunk.lines << { kind: :context, text: hl }
+          old_ln += 1
+          new_ln += 1
+        else
+          break
+        end
+
+        @i += 1
+      end
+
+      current.hunks << hunk
+    end
+  end
+end

--- a/lib/flatito/diff_source.rb
+++ b/lib/flatito/diff_source.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "English"
+
+module Flatito
+  module DiffSource
+    NULL_BLOB = "0000000"
+
+    module_function
+
+    def contents_for(file)
+      before = file.new_file ? nil : load_side(file.before_blob, file.before_path, file)
+      after = file.deleted_file ? nil : load_side(file.after_blob, file.after_path, file, after_side: true)
+      [before, after]
+    end
+
+    def load_side(blob, path, file, after_side: false)
+      content = blob_content(blob)
+      return content if content
+
+      content = working_tree_content(path) if after_side
+      return content if content
+
+      reconstruct_from_hunks(file, after_side: after_side)
+    end
+
+    def blob_content(blob)
+      return nil if blob.nil? || blob.start_with?(NULL_BLOB)
+
+      output = IO.popen(["git", "cat-file", "-p", blob], err: File::NULL, &:read)
+      return nil unless $CHILD_STATUS&.exitstatus&.zero?
+
+      output
+    rescue Errno::ENOENT
+      nil
+    end
+
+    def working_tree_content(path)
+      return nil if path.nil? || path.empty?
+      return nil unless ::File.file?(path)
+
+      ::File.read(path)
+    rescue StandardError
+      nil
+    end
+
+    def reconstruct_from_hunks(file, after_side:)
+      lines = []
+      file.hunks.each do |hunk|
+        target_line = after_side ? hunk.new_start : hunk.old_start
+        pad_until(lines, target_line - 1)
+        hunk.lines.each do |entry|
+          case entry[:kind]
+          when :context
+            lines << entry[:text]
+          when :add
+            lines << entry[:text] if after_side
+          when :del
+            lines << entry[:text] unless after_side
+          end
+        end
+      end
+      lines.join
+    end
+
+    def pad_until(lines, target_index)
+      lines << "\n" while lines.size < target_index
+    end
+  end
+end

--- a/lib/flatito/flatten_yaml.rb
+++ b/lib/flatito/flatten_yaml.rb
@@ -2,7 +2,7 @@
 
 module Flatito
   class FlattenYaml
-    Item = Struct.new(:key, :value, :line, keyword_init: true)
+    Item = Struct.new(:key, :value, :line, :marker, keyword_init: true)
     class << self
       def items_from_path(pathname)
         content = File.read(pathname)

--- a/lib/flatito/renderer.rb
+++ b/lib/flatito/renderer.rb
@@ -55,7 +55,16 @@ module Flatito
                 ""
               end
 
-      stdout.puts "#{line_number} #{matched_string(item.key)} #{value}"
+      marker = marker_prefix(item)
+      stdout.puts "#{marker}#{line_number} #{matched_string(item.key)} #{value}"
+    end
+
+    def marker_prefix(item)
+      case item.marker
+      when :add then colorize("+ ", :green)
+      when :del then colorize("- ", :red)
+      else ""
+      end
     end
 
     private

--- a/test/fixtures/sample.diff
+++ b/test/fixtures/sample.diff
@@ -1,0 +1,13 @@
+diff --git a/test/fixtures/diff_sample.yml b/test/fixtures/diff_sample.yml
+index 1111111..2222222 100644
+--- a/test/fixtures/diff_sample.yml
++++ b/test/fixtures/diff_sample.yml
+@@ -1,5 +1,7 @@
+ nested1:
+-  one: One
++  one: OneModified
+   nested2:
+     two: Two
++    extra: Extra
+ three: Three
++four: Four

--- a/test/flatito/diff_parser_test.rb
+++ b/test/flatito/diff_parser_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Flatito::DiffParserTest < Minitest::Test
+  test "detects diff content" do
+    assert Flatito::DiffParser.diff?(File.read("test/fixtures/sample.diff"))
+    assert Flatito::DiffParser.diff?("diff --git a/x b/x\nfoo")
+    refute Flatito::DiffParser.diff?("nested1:\n  one: One\n")
+    refute Flatito::DiffParser.diff?(nil)
+    refute Flatito::DiffParser.diff?("")
+  end
+
+  test "parses a single-file diff" do
+    files = Flatito::DiffParser.parse(File.read("test/fixtures/sample.diff"))
+
+    assert_equal 1, files.size
+    file = files.first
+
+    assert_equal "test/fixtures/diff_sample.yml", file.path
+    assert_equal "1111111", file.before_blob
+    assert_equal "2222222", file.after_blob
+    refute file.new_file
+    refute file.deleted_file
+
+    assert_equal Set.new([2, 5, 7]), file.added_lines
+    assert_equal Set.new([2]), file.removed_lines
+    assert_equal 1, file.hunks.size
+    assert_equal 1, file.hunks.first.old_start
+    assert_equal 1, file.hunks.first.new_start
+  end
+
+  test "parses a new file (--- /dev/null)" do
+    diff = <<~DIFF
+      diff --git a/new.yml b/new.yml
+      new file mode 100644
+      index 0000000..abcdef0
+      --- /dev/null
+      +++ b/new.yml
+      @@ -0,0 +1,2 @@
+      +alpha: 1
+      +beta: 2
+    DIFF
+
+    files = Flatito::DiffParser.parse(diff)
+
+    assert_equal 1, files.size
+    file = files.first
+
+    assert file.new_file
+    assert_equal Set.new([1, 2]), file.added_lines
+    assert_empty file.removed_lines
+  end
+
+  test "parses a deleted file (+++ /dev/null)" do
+    diff = <<~DIFF
+      diff --git a/gone.yml b/gone.yml
+      deleted file mode 100644
+      index abcdef0..0000000
+      --- a/gone.yml
+      +++ /dev/null
+      @@ -1,2 +0,0 @@
+      -alpha: 1
+      -beta: 2
+    DIFF
+
+    files = Flatito::DiffParser.parse(diff)
+
+    assert_equal 1, files.size
+    file = files.first
+
+    assert file.deleted_file
+    assert_empty file.added_lines
+    assert_equal Set.new([1, 2]), file.removed_lines
+  end
+
+  test "parses multiple files" do
+    diff = <<~DIFF
+      diff --git a/a.yml b/a.yml
+      index 1111111..2222222 100644
+      --- a/a.yml
+      +++ b/a.yml
+      @@ -1,1 +1,1 @@
+      -x: 1
+      +x: 2
+      diff --git a/b.yml b/b.yml
+      index 3333333..4444444 100644
+      --- a/b.yml
+      +++ b/b.yml
+      @@ -1,1 +1,2 @@
+       y: 1
+      +z: 2
+    DIFF
+
+    files = Flatito::DiffParser.parse(diff)
+
+    assert_equal 2, files.size
+    assert_equal "a.yml", files[0].path
+    assert_equal "b.yml", files[1].path
+    assert_equal Set.new([1]), files[0].added_lines
+    assert_equal Set.new([2]), files[1].added_lines
+  end
+end

--- a/test/flatito/from_diff_test.rb
+++ b/test/flatito/from_diff_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Flatito::FromDiffTest < Minitest::Test
+  class CapturedIO < StringIO
+    def tty?
+      false
+    end
+  end
+
+  def setup
+    @stdout = CapturedIO.new
+    Flatito::Config.stdout = @stdout
+    Flatito::Config.prepare_with_options(no_color: true)
+  end
+
+  def diff
+    File.read("test/fixtures/sample.diff")
+  end
+
+  test "from_diff side=both reports added and removed items" do
+    matched = Flatito.from_diff(diff, no_color: true, side: :both)
+
+    assert matched
+    output = @stdout.string
+
+    assert_includes output, "test/fixtures/diff_sample.yml"
+    assert_includes output, "+ "
+    assert_includes output, "- "
+    assert_includes output, "nested1.one"
+    assert_includes output, "nested1.nested2.extra"
+    assert_includes output, "four"
+  end
+
+  test "from_diff side=after only reports added items" do
+    matched = Flatito.from_diff(diff, no_color: true, side: :after)
+
+    assert matched
+    output = @stdout.string
+
+    assert_includes output, "+ "
+    refute_includes output, "- "
+  end
+
+  test "from_diff side=before only reports removed items" do
+    matched = Flatito.from_diff(diff, no_color: true, side: :before)
+
+    assert matched
+    output = @stdout.string
+
+    assert_includes output, "- "
+    refute_includes output, "+ "
+  end
+
+  test "from_diff respects search key filter" do
+    matched = Flatito.from_diff(diff, no_color: true, side: :both, search: "extra")
+
+    assert matched
+    output = @stdout.string
+
+    assert_includes output, "nested1.nested2.extra"
+    refute_includes output, "four"
+  end
+
+  test "from_diff returns false when no item matches search" do
+    matched = Flatito.from_diff(diff, no_color: true, side: :both, search: "no-such-key")
+
+    refute matched
+  end
+
+  test "from_diff filters by extension" do
+    other_diff = <<~DIFF
+      diff --git a/foo.txt b/foo.txt
+      index 1111111..2222222 100644
+      --- a/foo.txt
+      +++ b/foo.txt
+      @@ -1,1 +1,1 @@
+      -hello
+      +world
+    DIFF
+
+    refute Flatito.from_diff(other_diff, no_color: true)
+  end
+end


### PR DESCRIPTION
## Summary

- New `Flatito.from_diff` entry point that parses a unified diff and reports only the YAML/JSON entries living on `+`/`-` lines, each prefixed accordingly.
- Diff input is auto-detected on stdin (`git diff | flatito ...`) and on a single positional file (`flatito changes.diff`); existing search and `cat file.yaml | flatito` paths are unchanged.
- Adds a `--side=before|after|both` flag to pick which side of the change to print.
- When the diff carries git index hashes, before/after content is fetched via `git cat-file` so nested keys retain their parent context. Falls back to working tree and to hunk reconstruction when blobs aren't available.

## Test plan

- [x] `bundle exec rake test` (30 runs / 129 assertions)
- [x] `bundle exec rubocop` clean
- [x] Manual: `git diff <ref>~1 <ref> -- '*.yml' | exe/flatito` against this repo's history shows expected `+`/`-` items
- [x] Manual: `exe/flatito test/fixtures/sample.diff` and `cat test/fixtures/sample.diff | exe/flatito` produce identical output, with `--side=after` and `--side=before` filtering correctly
- [x] Existing usage (`flatito PATH -k ...` and `cat file.yaml | flatito ...`) verified unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)