### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Ruby
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ceritium/flatito/security/code-scanning/2](https://github.com/ceritium/flatito/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/main.yml` at the workflow root level (top-level, alongside `name` and `on`) so it applies to all jobs unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read`

This preserves current functionality (checkout + test execution) while constraining token capabilities and satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
